### PR TITLE
Removing the extra space in front of the code segments which is breaking the mkdocs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,52 +147,52 @@ Refer to the complete implementation of the book store service in the [loadbalan
 ### Try it out
 #### Load balancer
 1. Run the book search service by running the following command in the terminal from the `SAMPLE_ROOT/src` directory.
-    ```bash
-    $ ballerina run booksearchservice/
-   ```
+```bash
+$ ballerina run booksearchservice/
+```
 
 2. Next, run the three instances of the book store service. Here you have to enter the service port number in each service instance. You can pass the port number as parameter `Bport=<Port Number>`.
-   ``` bash
-   // 1st instance with port number 9011
-   $ ballerina run bookstorebacked/ -Bport=9011
-   ```
-   
-    ``` bash
-    // 2nd instance with port number 9012
-    $ ballerina run bookstorebacked/ -Bport=9012
-   ```
-   
-    ``` bash
-    // 3rd instance with port number 9013
-    $ ballerina run bookstorebacked/ -Bport=9013
-   ```
+``` bash
+// 1st instance with port number 9011
+$ ballerina run bookstorebacked/ -Bport=9011
+```
+
+``` bash
+// 2nd instance with port number 9012
+$ ballerina run bookstorebacked/ -Bport=9012
+```
+
+``` bash
+// 3rd instance with port number 9013
+$ ballerina run bookstorebacked/ -Bport=9013
+```
    With that, all the required services for this guide should be up and running.
   
 3. Invoke the book search service by sending the following HTTP GET request to the book search service.
-   ```bash
-   curl -X GET http://localhost:9090/book/Carrie
-   ```
-   You should see a response silmilar to the following.
-   ```json
-   {"Served by Data Ceter":1,"Book Details":{"Title":"Carrie","Author":"Stephen King"
-   ,"ISBN":"978-3-16-148410-   0","Availability":"Available"}}
-   ```
+```bash
+curl -X GET http://localhost:9090/book/Carrie
+```
+You should see a response silmilar to the following.
+```json
+{"Served by Data Ceter":1,"Book Details":{"Title":"Carrie","Author":"Stephen King"
+,"ISBN":"978-3-16-148410-   0","Availability":"Available"}}
+```
    The`"Served by Data Ceter":1` entry says that the 1st instance of book store backend has been invoked to find the book details.
 
 4. Repeat the above request three times. You should see the responses as follows.
 
-   ```json
-   {"Served by Data Ceter":2,"Book Details":{"Title":"Carrie","Author":"Stephen King",
-   "ISBN":"978-3-16-148410-   0","Availability":"Available"}}
-   ```
-   ```json
-   {"Served by Data Ceter":3,"Book Details":{"Title":"Carrie","Author":"Stephen King",
-   "ISBN":"978-3-16-148410-   0","Availability":"Available"}}
-   ```
-   ```json
-   {"Served by Data Ceter":1,"Book Details":{"Title":"Carrie","Author":"Stephen King",
-   "ISBN":"978-3-16-148410-   0","Availability":"Available"}}
-   ```
+```json
+{"Served by Data Ceter":2,"Book Details":{"Title":"Carrie","Author":"Stephen King",
+"ISBN":"978-3-16-148410-   0","Availability":"Available"}}
+```
+```json
+{"Served by Data Ceter":3,"Book Details":{"Title":"Carrie","Author":"Stephen King",
+"ISBN":"978-3-16-148410-   0","Availability":"Available"}}
+```
+```json
+{"Served by Data Ceter":1,"Book Details":{"Title":"Carrie","Author":"Stephen King",
+"ISBN":"978-3-16-148410-   0","Availability":"Available"}}
+```
 
 You can see that the book search service has invoked the book store backed with the round robin load balancing pattern. The `"Served by Data Ceter"` repeats using the following pattern: 1 -> 2 -> 3 -> 1.
 
@@ -200,32 +200,32 @@ You can see that the book search service has invoked the book store backed with 
 #### Load balancer: some servers down
 
 1.  Now shut down the third instance of the book store service by terminating the following instance.
-    ```bash
-    // 3rd instance with port number 9013
-    $ ballerina run bookstorebacked/ -Bport=9013
-    // Terminate this from the terminal
-    ``` 
+```bash
+// 3rd instance with port number 9013
+$ ballerina run bookstorebacked/ -Bport=9013
+// Terminate this from the terminal
+``` 
 2.  Then send following request repeatedly three times,
-    ```bash
-    curl -X GET http://localhost:9090/book/Carrie
-    ```  
+```bash
+curl -X GET http://localhost:9090/book/Carrie
+```  
 3.  The responses for above requests should look similar to,
-    ```json
-    {"Served by Data Ceter":1,"Book Details":{"Title":"Carrie","Author":"Stephen King",
-    "ISBN":"978-3-16-148410-    0","Availability":"Available"}}
-    ```
-    ```json
-    {"Served by Data Ceter":2,"Book Details":{"Title":"Carrie","Author":"Stephen King",
-    "ISBN":"978-3-16-148410-   0","Availability":"Available"}}
-    ```
-    ```json
-    {"Served by Data Ceter":1,"Book Details":{"Title":"Carrie","Author":"Stephen King",
-    "ISBN":"978-3-16-148410-   0","Availability":"Available"}}
-    ```
+```json
+{"Served by Data Ceter":1,"Book Details":{"Title":"Carrie","Author":"Stephen King",
+"ISBN":"978-3-16-148410-    0","Availability":"Available"}}
+```
+```json
+{"Served by Data Ceter":2,"Book Details":{"Title":"Carrie","Author":"Stephen King",
+"ISBN":"978-3-16-148410-   0","Availability":"Available"}}
+```
+```json
+{"Served by Data Ceter":1,"Book Details":{"Title":"Carrie","Author":"Stephen King",
+"ISBN":"978-3-16-148410-   0","Availability":"Available"}}
+```
    
 4. This means that the loadbalancer is preventing the third instance from getting invoked since the third instance is shut down. In the meantime you'll see the order of `"Served by Data Ceter"` is similar to the 1 -> 2 -> 1 pattern.
  
- ### Writing unit tests 
+### Writing unit tests 
 
 In Ballerina, the unit test cases should be in the same package under the `tests` folder .
 The naming convention should be as follows.
@@ -248,18 +248,18 @@ You can deploy the RESTful service that you developed above in your local enviro
 
 **Building** 
 Navigate to `SAMPLE_ROOT/src` and run the following commands
-   ```bash
-    $ ballerina build book_store_backed/
+```bash
+$ ballerina build book_store_backed/
 
-    $ ballerina build book_search/
-   ```
+$ ballerina build book_search/
+```
 
 **Running**
-   ```bash
-    $ ballerina run book_store_backed.balx
+```bash
+$ ballerina run book_store_backed.balx
 
-    $ ballerina run book_search.balx -Bport=9011
-   ```
+$ ballerina run book_search.balx -Bport=9011
+```
 
 ### Deploying on Docker
 
@@ -294,25 +294,25 @@ service<http:Service> bookSearchService bind bookSearchServiceEP {
 - Now you can build a Ballerina executable archive (.balx) of the service that we developed above, using the following command. It points to the service file that we developed above and it will create an executable binary out of that. 
 This will also create the corresponding docker image using the docker annotations that you have configured above. Navigate to the `<SAMPLE_ROOT>/src/` folder and run the following command.  
   
-  ```
-  $ballerina build book_search
-  
-  Run following command to start docker container: 
-  docker run -d -p 9090:9090 ballerina.guides.io/book_search_service:v1.0
-  ```
+```
+$ballerina build book_search
+
+Run following command to start docker container: 
+docker run -d -p 9090:9090 ballerina.guides.io/book_search_service:v1.0
+```
 - Once you successfully build the docker image, you can run it with the `` docker run`` command that is shown in the previous step.  
 
-    ```   
-    docker run -d -p 9090:9090 ballerina.guides.io/book_search_service:v1.0
-    ```
+```   
+docker run -d -p 9090:9090 ballerina.guides.io/book_search_service:v1.0
+```
     Here we run the docker image with flag`` -p <host_port>:<container_port>`` so that we use the host port 9090 and the container port 9090. Therefore you can access the service through the host port. 
 
 - Verify docker container is running with the use of `` $ docker ps``. The status of the docker container should be shown as 'Up'. 
 - You can access the service using the same curl commands that we've used above. 
  
-    ```
-   curl -X GET http://localhost:9090/book/Carrie
-    ```
+```
+curl -X GET http://localhost:9090/book/Carrie
+```
 
 
 ### Deploying on Kubernetes
@@ -365,12 +365,12 @@ service<http:Service> bookSearchService bind bookSearchServiceEP {
 - Now you can build a Ballerina executable archive (.balx) of the service that we developed above, using the following command. It points to the service file that we developed above and it will create an executable binary out of that. 
 This will also create the corresponding docker image and the Kubernetes artifacts using the Kubernetes annotations that you have configured above.
   
-  ```
-  $ballerina build book_search
-  
-  Run following command to deploy kubernetes artifacts:  
-  kubectl apply -f ./target/book_search/kubernetes
-  ```
+```
+$ballerina build book_search
+
+Run following command to deploy kubernetes artifacts:  
+kubectl apply -f ./target/book_search/kubernetes
+```
 
 - You can verify that the docker image that we specified in `` @kubernetes:Deployment `` is created, by using `` docker ps images ``. 
 - Also the Kubernetes artifacts related our service, will be generated in `` ./target/book_search/kubernetes``. 

--- a/README.md
+++ b/README.md
@@ -296,8 +296,9 @@ This will also create the corresponding docker image using the docker annotation
   
 ```
 $ballerina build book_search
-
+```
 Run following command to start docker container: 
+```
 docker run -d -p 9090:9090 ballerina.guides.io/book_search_service:v1.0
 ```
 - Once you successfully build the docker image, you can run it with the `` docker run`` command that is shown in the previous step.  
@@ -367,8 +368,9 @@ This will also create the corresponding docker image and the Kubernetes artifact
   
 ```
 $ballerina build book_search
-
+```
 Run following command to deploy kubernetes artifacts:  
+```
 kubectl apply -f ./target/book_search/kubernetes
 ```
 


### PR DESCRIPTION
## Purpose
Removing the extra space in front of the code segments which is breaking the mkdocs build.

Before
<img width="958" alt="screen shot 2018-04-26 at 2 37 02 pm" src="https://user-images.githubusercontent.com/3424539/39296793-715f5772-495f-11e8-920d-4500d712cadc.png">

After
<img width="927" alt="screen shot 2018-04-26 at 2 36 44 pm" src="https://user-images.githubusercontent.com/3424539/39296775-69541f4a-495f-11e8-953c-08fac6cf6d98.png">


